### PR TITLE
Makes Archmundi load itself roundstart, adds verb to remove latejoining on the station, adds verb to enable latejoining on a new landmark

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -45,6 +45,7 @@ SUBSYSTEM_DEF(mapping)
 
 	// Z-manager stuff
 	var/station_start  // should only be used for maploading-related tasks
+	var/archmundi_start
 	var/space_levels_so_far = 0
 	var/list/z_list
 	///list of all z level indices that form multiz connections and whether theyre linked up or down.
@@ -323,6 +324,9 @@ SUBSYSTEM_DEF(mapping)
 		"}, list("map_name" = config.map_name, "round_id" = GLOB.round_id))
 		query_round_map_name.Execute()
 		qdel(query_round_map_name)
+
+	archmundi_start = world.maxz + 1
+	LoadArchimundi()
 
 #ifndef LOWMEMORYMODE
 	// TODO: remove this when the DB is prepared for the z-levels getting reordered

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -294,7 +294,7 @@ SUBSYSTEM_DEF(shuttle)
 	if (!SSticker.IsRoundInProgress())
 		return
 
-	var/callShuttle = 1
+	var/callShuttle = 0
 
 	for(var/thing in GLOB.shuttle_caller_list)
 		if(isAI(thing))

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -325,6 +325,9 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	SSjob.latejoin_trackers += loc
 	return INITIALIZE_HINT_QDEL
 
+/obj/effect/landmark/aterstation
+	name = "JoinLate After Station Leave"
+
 //space carps, magicarps, lone ops, slaughter demons, possibly revenants spawn here
 /obj/effect/landmark/carpspawn
 	name = "carpspawn"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -108,6 +108,8 @@ GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/healall,
 	/client/proc/spawn_floor_cluwne,
 	/client/proc/spawnhuman,
+	/client/proc/removestationlatejoining,
+	/client/proc/enableicelandlatejoining,
 	/client/proc/generateArchimundi
 	))
 GLOBAL_PROTECT(admin_verbs_fun)

--- a/code/modules/antagonists/halloween/Archimundispawner.dm
+++ b/code/modules/antagonists/halloween/Archimundispawner.dm
@@ -1,13 +1,12 @@
 /client/proc/generateArchimundi()
-	set name = "Generate Archimundi"
+	set name = "Delete Station"
 	set desc = "Deletes the Station and Generates Archimundi DO NOT PRESS LIGHTLY"
 	set category = "Fun"
 
 	if(!check_rights(R_PERMISSIONS))
 		return
 	log_admin("[key_name(usr)] Started generating Archimundi.")
-	SSzclear.wipe_z_level(2, TRUE)
-	LoadArchimundi()
+	SSzclear.wipe_z_level(2)
 	log_admin("[key_name(usr)] Generated Archimundi.")
 
 /proc/LoadArchimundi()
@@ -16,5 +15,32 @@
 	if(archimundi_loaded)
 		return
 	var/datum/map_template/template = new("_maps/map_files/RadStation/RadStation.dmm", "Archimundi")
-	template.load_new_z(null, ZTRAITS_STATION)
+	template.load_new_z()
 	archimundi_loaded = TRUE
+
+/client/proc/removestationlatejoining()
+	set name = "Turn Off Station Latejoins"
+	set desc = "Stops latejoins and deletes the arrivals shuttle"
+	set category = "Fun"
+
+	if(!check_rights(R_FUN))
+		return
+	var/static/disabled_latejoins = FALSE
+	if(disabled_latejoins)
+		return
+	log_admin("[key_name(usr)] Removed latejoining on the station.")
+	SSticker.late_join_disabled = TRUE
+	SSshuttle.arrivals.jumpToNullSpace()
+	disabled_latejoins = TRUE
+
+/client/proc/enableicelandlatejoining()
+	set name = "Enables Late joining after abandoning Station"
+	set desc = "Adds new landmarks to latejoining and renables latejoining"
+	set category = "Fun"
+
+	if(!check_rights(R_FUN))
+		return
+	for(var/obj/effect/landmark/icelate/L in GLOB.landmarks_list)
+		SSjob.latejoin_trackers += L.loc
+	SSticker.late_join_disabled = FALSE
+


### PR DESCRIPTION
Add the new landmark to wherever people are supposed to spawn after station is abandoned.
Also removes automatic shuttle call which was being annoying.
