### PR TITLE
Virtual multi-z support cherry pick

### DIFF
--- a/code/__DEFINES/multi_z.dm
+++ b/code/__DEFINES/multi_z.dm
@@ -9,7 +9,30 @@
 #define Z_LEVEL_DOWN 2
 #define LARGEST_Z_LEVEL_INDEX Z_LEVEL_DOWN
 
-/// Attempt to get the turf below the provided one according to Z traits
-#define GET_TURF_BELOW(turf) ((!(turf) || !length(SSmapping.multiz_levels) || !SSmapping.multiz_levels[(turf).z][Z_LEVEL_DOWN]) ? null : get_step((turf), DOWN))
-/// Attempt to get the turf above the provided one according to Z traits
-#define GET_TURF_ABOVE(turf) ((!(turf) || !length(SSmapping.multiz_levels) || !SSmapping.multiz_levels[(turf).z][Z_LEVEL_UP]) ? null : get_step((turf), UP))
+/// The below procs require you to either directly pass in a turf, or assign to a turf typed variable
+/// The unsafe access to above needs to be null checked otherwise the compiler gets confused with the ternary
+/// expression.
+
+/// Attempt to get the turf below the provided one according to either
+/// the map config defined z-traits, or the assigned below turf.
+#define GET_TURF_BELOW(turf) \
+( \
+	!(turf) ? null : ( \
+		(turf).below || ( \
+			(turf).set_below(MAPPING_TURF_BELOW(turf)) \
+		) \
+	) \
+)
+#define MAPPING_TURF_BELOW(turf) ((!(turf) || !length(SSmapping.multiz_levels) || !SSmapping.multiz_levels[(turf).z][Z_LEVEL_DOWN]) ? null : get_step((turf), DOWN))
+
+/// Attempt to get the turf above the provided one according to either
+/// the map config defined z-traits, or the assigned above turf
+#define GET_TURF_ABOVE(turf) \
+( \
+	!(turf) ? null : ( \
+		(turf).above || ( \
+			(turf).set_above(MAPPING_TURF_ABOVE(turf)) \
+		) \
+	) \
+)
+#define MAPPING_TURF_ABOVE(turf) ((!(turf) || !length(SSmapping.multiz_levels) || !SSmapping.multiz_levels[(turf).z][Z_LEVEL_UP]) ? null : get_step((turf), UP))

--- a/code/__DEFINES/zmimic.dm
+++ b/code/__DEFINES/zmimic.dm
@@ -60,3 +60,5 @@ GLOBAL_LIST_INIT(z_defines, list(
 On ZMM_AUTOMANGLE:
 	It's separate from ZMM_MANGLE_PLANES so SSoverlays doesn't disable mangling on a manually flagged atom.
 */
+
+#define GET_TURF_DEPTH(turf) (!isnull((turf).z_depth) ? (turf).z_depth : (turf).calculate_zdepth())

--- a/code/_onclick/hud/ai.dm
+++ b/code/_onclick/hud/ai.dm
@@ -186,7 +186,7 @@
 		return
 	var/mob/living/silicon/ai/AI = usr
 	var/turf/T = get_turf(AI.eyeobj)
-	var/turf/target = upwards ? T.above() : T.below()
+	var/turf/target = upwards ? GET_TURF_ABOVE(T) : GET_TURF_BELOW(T)
 	if(isturf(target))
 		AI.eyeobj.forceMove(target)
 		AI.overlay_fullscreen("flash", /atom/movable/screen/fullscreen/flash/static)

--- a/code/controllers/subsystem/zcopy.dm
+++ b/code/controllers/subsystem/zcopy.dm
@@ -26,10 +26,6 @@ SUBSYSTEM_DEF(zcopy)
 	var/multiqueue_skips_turf = 0
 	var/multiqueue_skips_object = 0
 
-	// Highest Z level in a given Z-group for absolute layering.
-	// zstm[zlev] = group_max
-	var/list/zlev_maximums = list()
-
 	// Caches for fixup.
 	var/list/fixup_cache = list()
 	var/list/fixup_known_good = list()
@@ -114,8 +110,6 @@ SUBSYSTEM_DEF(zcopy)
 /datum/controller/subsystem/zcopy/stat_entry(msg)
 	var/list/entries = list(
 		"",	// newline
-		"\tZSt: [build_zstack_display()]",	// This is a human-readable list of the z-stacks known to ZM.
-		"\tZMx: [zlev_maximums.Join(", ")]",	// And this is the raw internal state.
 		// This one gets broken out from the below because it's more important.
 		"\tQ: { T: [queued_turfs.len - (qt_idex - 1)] O: [queued_overlays.len - (qo_idex - 1)] }",
 		// In order: Total, Skipped
@@ -124,50 +118,11 @@ SUBSYSTEM_DEF(zcopy)
 	)
 	return ..(entries.Join("\n"))
 
-// 1, 2, 3..=7, 8
-/datum/controller/subsystem/zcopy/proc/build_zstack_display()
-	if (!zlev_maximums.len)
-		return "<none>"
-	var/list/zmx = list()
-	var/idx = 1
-	var/span_ctr = 0
-	do
-		if (zlev_maximums[idx] != idx)
-			span_ctr += 1
-		else if (span_ctr)
-			zmx += "[idx - span_ctr]..=[idx]"
-			span_ctr = 0
-		else
-			zmx += "[idx]"
-		idx += 1
-	while (idx <= zlev_maximums.len)
-	return jointext(zmx, ", ")
 
 /datum/controller/subsystem/zcopy/Initialize(timeofday)
-	calculate_zstack_limits()
 	// Flush the queue.
 	fire(FALSE, TRUE)
 	return ..()
-
-// If you add a new Zlevel or change Z-connections, call this.
-/datum/controller/subsystem/zcopy/proc/calculate_zstack_limits()
-	zlev_maximums = new(world.maxz)
-	var/start_zlev = 1
-	for (var/z in 1 to world.maxz)
-		var/offset = SSmapping.level_trait(z, ZTRAIT_UP)
-		if (offset != 1)
-			if (offset > 1)
-				log_game("Z-Mimic: WARNING: Z-level [z] is nonlinear (offset [offset]), it is being ignored.")
-
-			for (var/member_zlev in start_zlev to z)
-				zlev_maximums[member_zlev] = z
-			if (z - start_zlev > ZMIMIC_MAX_DEPTH)
-				log_game("Z-Mimic: WARNING: Z-levels [start_zlev] through [z] exceed maximum depth of [ZMIMIC_MAX_DEPTH]; layering may behave strangely in this Z-stack.")
-			else if (z - start_zlev > 1)
-				log_game("Z-Mimic: Found Z-Stack: [start_zlev] -> [z] = [z - start_zlev + 1] zl")
-			start_zlev = z + 1
-
-	log_game("Z-Mimic: Z-Level maximums: [json_encode(zlev_maximums)]")
 
 /datum/controller/subsystem/zcopy/StartLoadingMap()
 	can_fire = FALSE
@@ -244,8 +199,7 @@ SUBSYSTEM_DEF(zcopy)
 			Td = Td.below
 
 		// Depth must be the depth of the *visible* turf, not self.
-		var/turf_depth
-		turf_depth = T.z_depth = zlev_maximums[Td.z] - Td.z
+		var/turf_depth = ZMIMIC_MAX_DEPTH - GET_TURF_DEPTH(Td)
 
 		var/t_target = ZMIMIC_MAX_PLANE - turf_depth	// This is where the turf (but not the copied atoms) gets put.
 
@@ -343,7 +297,7 @@ SUBSYSTEM_DEF(zcopy)
 
 			var/override_depth
 			var/original_type = object.type
-			var/original_z = object.z
+			var/original_depth = GET_TURF_DEPTH(T.below)
 			var/have_performed_fixup = FALSE
 
 			switch (object.type)
@@ -352,7 +306,7 @@ SUBSYSTEM_DEF(zcopy)
 					var/atom/movable/openspace/mimic/OOO = object
 					original_type = OOO.mimiced_type
 					override_depth = OOO.override_depth
-					original_z = OOO.original_z
+					original_depth = OOO.original_depth
 					have_performed_fixup = OOO.have_performed_fixup
 
 				// If this is a turf proxy (the mimic for a non-OVERWRITE turf), it needs to respect space parallax if relevant.
@@ -362,7 +316,7 @@ SUBSYSTEM_DEF(zcopy)
 						override_depth = ZMIMIC_MAX_PLANE - PLANE_SPACE
 
 				if (/atom/movable/openspace/turf_mimic)
-					original_z += 1
+					original_depth += 1
 
 			var/atom/movable/openspace/mimic/OO = object.bound_overlay
 
@@ -371,7 +325,7 @@ SUBSYSTEM_DEF(zcopy)
 				deltimer(OO.destruction_timer)
 				OO.destruction_timer = null
 
-			OO.depth = override_depth || min(zlev_maximums[T.z] - original_z, ZMIMIC_MAX_DEPTH)
+			OO.depth = override_depth || min(ZMIMIC_MAX_DEPTH - original_depth, ZMIMIC_MAX_DEPTH)
 
 			// These types need to be pushed a layer down for bigturfs to function correctly.
 			switch (original_type)
@@ -381,7 +335,7 @@ SUBSYSTEM_DEF(zcopy)
 
 			OO.mimiced_type = original_type
 			OO.override_depth = override_depth
-			OO.original_z = original_z
+			OO.original_depth = original_depth
 			OO.have_performed_fixup ||= have_performed_fixup
 
 			// Multi-queue to maintain ordering of updates to these
@@ -652,7 +606,7 @@ SUBSYSTEM_DEF(zcopy)
 		"<b>Has above copy:</b> [T.mimic_above_copy ? "Yes" : "No"]",
 		"<b>Has mimic underlay:</b> [T.mimic_underlay ? "Yes" : "No"]",
 		"<b>Below:</b> [!T.below ? "(nothing)" : "[T.below] at [T.below.x],[T.below.y],[T.below.z]"]",
-		"<b>Depth:</b> [FMT_DEPTH(T.z_depth)] [T.z_depth == ZMIMIC_MAX_DEPTH ? "(max)" : ""]",
+		"<b>Depth:</b> [FMT_DEPTH(GET_TURF_DEPTH(T))] [GET_TURF_DEPTH(T) == ZMIMIC_MAX_DEPTH ? "(max)" : ""]",
 		"<b>Generation:</b> [T.z_generation]",
 		"<b>Update count:</b> Claimed [claimed_update_count], Actual [real_update_count] - [claimed_update_count == real_update_count ? "<font color='green'>OK</font>" : "<font color='red'>MISMATCH</font>"]",
 		"<ul>"
@@ -667,7 +621,7 @@ SUBSYSTEM_DEF(zcopy)
 	var/turf/Tbelow = T
 	while ((Tbelow = Tbelow.below))
 		var/atom/movable/openspace/debug/turf/VTO = new
-		VTO.computed_depth = SSzcopy.zlev_maximums[Tbelow.z] - Tbelow.z
+		VTO.computed_depth = ZMIMIC_MAX_DEPTH - GET_TURF_DEPTH(Tbelow)
 		VTO.appearance = Tbelow
 		VTO.parent = Tbelow
 		VTO.plane = ZMIMIC_MAX_PLANE - VTO.computed_depth

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -451,7 +451,7 @@
 	if (bound_overlay)
 		// The overlay will handle cleaning itself up on non-openspace turfs.
 		if (isturf(loc))
-			bound_overlay.forceMove(get_step(src, UP))
+			bound_overlay.forceMove(get_step_multiz(src, UP))
 			if (bound_overlay && dir != bound_overlay.dir)
 				bound_overlay.setDir(dir)
 		else	// Not a turf, so we need to destroy immediately instead of waiting for the destruction timer to proc.

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -491,7 +491,7 @@ GLOBAL_LIST_INIT(meteorsSPOOKY, list(/obj/effect/meteor/pumpkin))
 	var/turf/current = loc
 	if (!istype(current))
 		return FALSE
-	var/turf/below = current.below()
+	var/turf/below = GET_TURF_BELOW(current)
 	//Move down a layer and fall again
 	if (below != null)
 		forceMove(below)

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -397,7 +397,7 @@ DEFINE_BUFFER_HANDLER(/obj/machinery/porta_turret)
 	var/turf/temp = get_turf(src)
 	while(temp && (isspaceturf(temp) || temp == get_turf(src)))
 		valid_turfs["[temp.z]"] = temp
-		temp = temp.above()
+		temp = GET_TURF_ABOVE(temp)
 
 	var/list/targets = list()
 	for(var/turf_z as() in valid_turfs)

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -87,8 +87,10 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	var/old_directional_opacity = directional_opacity
 	var/old_opacity = opacity
 
-	// Z-Mimic: copy above
-	var/old_above = above
+	// Dynamic Z-Linking
+	var/turf/old_above = above
+	var/turf/old_below = below
+	var/old_zdepth = z_depth
 
 	var/old_exl = explosion_level
 	var/old_exi = explosion_id
@@ -105,7 +107,23 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	//We do this here so anything that doesn't want to persist can clear itself
 	var/list/old_comp_lookup = comp_lookup?.Copy()
 	var/list/old_signal_procs = signal_procs?.Copy()
+
+	var/old_atoms_state = SSatoms.initialized
+	SSatoms.initialized = INITIALIZATION_INSSATOMS
 	var/turf/new_turf = new path(src)
+
+	// These need to be set prior to initialisation, otherwise we will have to regenerate
+	// zmimic twice for turfs that are linked to other locations.
+	new_turf.above = old_above
+	old_above?.below = new_turf
+	new_turf.below = old_below
+	old_below?.above = new_turf
+	new_turf.z_depth = old_zdepth
+
+	var/is_mapload = old_atoms_state == INITIALIZATION_INNEW_MAPLOAD
+	SSatoms.InitAtom(src, new_turf, is_mapload)
+
+	SSatoms.initialized = old_atoms_state
 
 	// WARNING WARNING
 	// Turfs DO NOT lose their signals when they get replaced, REMEMBER THIS
@@ -122,8 +140,6 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		new_turf.baseturfs = baseturfs_string_list(new_baseturfs, new_turf)
 	else
 		new_turf.baseturfs = baseturfs_string_list(old_baseturfs, new_turf) //Just to be safe
-
-	new_turf.above = old_above
 
 	new_turf.explosion_id = old_exi
 	new_turf.explosion_level = old_exl

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -26,7 +26,7 @@
 /turf/open/openspace/can_have_cabling()
 	if(locate(/obj/structure/lattice/catwalk, src))
 		return TRUE
-	var/turf/B = below()
+	var/turf/B = GET_TURF_BELOW(src)
 	if(B)
 		return B.can_lay_cable()
 	return FALSE
@@ -142,7 +142,7 @@
 
 //Returns FALSE if gravity is force disabled. True if grav is possible
 /turf/open/openspace/check_gravity()
-	var/turf/T = below()
+	var/turf/T = GET_TURF_BELOW(src)
 	if(!T)
 		return TRUE
 	if(isspaceturf(T))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -7,6 +7,11 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 	/// If this is TRUE, that means this floor is on top of plating so pipes and wires and stuff will appear under it... or something like that it's not entirely clear.
 	var/intact = 1
 
+	/// The turf that we are linked to below
+	var/tmp/turf/below = null
+	/// The turf that we are linked to above
+	var/tmp/turf/above = null
+
 	// baseturfs can be either a list or a single turf type.
 	// In class definition like here it should always be a single type.
 	// A list will be created in initialization that figures out the baseturf's baseturf etc.
@@ -64,6 +69,13 @@ GLOBAL_LIST_EMPTY(created_baseturf_lists)
 	var/static/list/banned_edits = list("x", "y", "z")
 	if(var_name in banned_edits)
 		return FALSE
+	switch (var_name)
+		if ("above")
+			set_above(new_value, TRUE)
+			return TRUE
+		if ("below")
+			set_below(new_value, TRUE)
+			return TRUE
 	. = ..()
 
 /turf/Initialize(mapload)

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -49,18 +49,9 @@
 	var/canpass = CANATMOSPASS(src, src)
 	var/canvpass = CANVERTICALATMOSPASS(src, src)
 	// I am essentially inlineing two get_dir_multizs here, because they're way too slow on their own. I'm sorry brother
-	var/list/z_traits = SSmapping.multiz_levels[z]
 	for(var/direction in GLOB.cardinals_multiz)
-		// Yes this is a reimplementation of get_step_mutliz. It's faster tho. fuck you
-		var/turf/current_turf = (direction & (UP|DOWN)) ? \
-			(direction & UP) ? \
-				(z_traits[Z_LEVEL_UP]) ? \
-					(get_step(locate(x, y, z + 1), NONE)) : \
-				(null) : \
-				(z_traits[Z_LEVEL_DOWN]) ? \
-					(get_step(locate(x, y, z - 1), NONE)) : \
-				(null) : \
-			(get_step(src, direction))
+		// Get step multi-z is cached now so is much faster
+		var/turf/current_turf = get_step_multiz(src, direction)
 		if(!isopenturf(current_turf))
 			continue
 		if(!is_closed && ((direction & (UP|DOWN)) ? (canvpass && CANVERTICALATMOSPASS(current_turf, src)) : (canpass && CANATMOSPASS(current_turf, src))))
@@ -85,18 +76,9 @@
 		return
 	if(disable_adjacent)
 		// I am essentially inlineing two get_dir_multizs here, because they're way too slow on their own. I'm sorry brother
-		var/list/z_traits = SSmapping.multiz_levels[z]
 		for(var/direction in GLOB.cardinals_multiz)
 			// Yes this is a reimplementation of get_step_mutliz. It's faster tho.
-			var/turf/current_turf = (direction & (UP|DOWN)) ? \
-				(direction & UP) ? \
-					(z_traits[Z_LEVEL_UP]) ? \
-						(get_step(locate(x, y, z + 1), NONE)) : \
-					(null) : \
-					(z_traits[Z_LEVEL_DOWN]) ? \
-						(get_step(locate(x, y, z - 1), NONE)) : \
-					(null) : \
-				(get_step(src, direction))
+			var/turf/current_turf = get_step_multiz(src, direction)
 			if(!istype(current_turf))
 				continue
 			if (current_turf.atmos_adjacent_turfs)

--- a/code/modules/multiz/movement/turf/turf_zmove.dm
+++ b/code/modules/multiz/movement/turf/turf_zmove.dm
@@ -3,10 +3,10 @@
 	if(get_turf(user) != src)
 		return
 	var/list/tool_list = list()
-	var/turf/above = above()
+	var/turf/above = GET_TURF_ABOVE(src)
 	if(above)
 		tool_list["Up"] = image(icon = 'icons/testing/turf_analysis.dmi', icon_state = "red_arrow", dir = NORTH)
-	var/turf/below = below()
+	var/turf/below = GET_TURF_BELOW(src)
 	if(below)
 		tool_list["Down"] = image(icon = 'icons/testing/turf_analysis.dmi', icon_state = "red_arrow", dir = SOUTH)
 

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -158,7 +158,7 @@
 	var/queued = 0
 	var/destruction_timer
 	var/mimiced_type
-	var/original_z
+	var/original_depth
 	var/override_depth
 	var/have_performed_fixup = FALSE
 

--- a/code/modules/multiz/zmimic/mimic_turf.dm
+++ b/code/modules/multiz/zmimic/mimic_turf.dm
@@ -1,6 +1,4 @@
 /turf
-	var/tmp/turf/above	//! If present, a turf above that is copying this turf. Implies a Z-connection and that the turf above is a z-mimic enabled turf.
-	var/tmp/turf/below	//! If present, the turf below that we are copying. Implies a Z-connection and that this is a z-mimic enabled turf.
 	// Various Z-Mimic abstract objects.
 	var/tmp/atom/movable/openspace/turf_proxy/mimic_proxy      //! If we're a non-overwrite z-turf, this holds the appearance of the bottom-most Z-turf in the z-stack.
 	var/tmp/atom/movable/openspace/multiplier/shadower         //! Object used to multiply color of all OO overlays at once.
@@ -11,7 +9,10 @@
 	/// If this Z-turf leads to space, uninterrupted.
 	var/tmp/z_eventually_space = FALSE
 	// debug
-	var/tmp/z_depth	//! Cached computed depth, used in analyzer.
+	/// The computed depth, this should never be directly accessed.
+	/// This is assumed to always be correct, so if below is changed it
+	/// must be invalidated by setting it to null.
+	var/tmp/z_depth = null
 	var/tmp/z_generation = 0	//! Update count, used in analyzer.
 	/// General MultiZ flags, not entirely related to zmimic but better than using obj_flags
 	var/z_flags = NONE
@@ -49,10 +50,7 @@
 		CRASH("Attempt to enable Z-mimic on already-enabled turf!")
 	shadower = new(src)
 	SSzcopy.openspace_turfs += 1
-	var/turf/under = GET_TURF_BELOW(src)
-	if (under)
-		below = under
-		below.above = src
+	GET_TURF_BELOW(src)
 	if (!(z_flags & (Z_MIMIC_OVERWRITE|Z_MIMIC_NO_OCCLUDE)) && mouse_opacity)
 		mouse_opacity = MOUSE_OPACITY_OPAQUE
 	update_mimic(!mapload) // Only recursively update if the map isn't loading.
@@ -74,12 +72,36 @@
 	if (above)
 		above.update_mimic()
 
-	if (below)
-		below.above = null
-		below = null
-
 /turf/Entered(atom/movable/thing, turf/oldLoc)
 	. = ..()
 	if ((thing.bound_overlay && !thing.bound_overlay.destruction_timer) || (thing.zmm_flags & ZMM_IGNORE) || thing.invisibility == INVISIBILITY_ABSTRACT || !TURF_IS_MIMICKING(above))
 		return
 	above.update_mimic()
+
+/// Calculate the z-depth of this provided turf.
+/turf/proc/calculate_zdepth()
+	z_depth = null
+	// Traverse to the bottom of the stack
+	var/turf/b = src.below || MAPPING_TURF_BELOW(src)
+	// We are the bottom
+	if (!b)
+		z_depth = 0
+		return z_depth
+	var/turf/nextb = b.below || MAPPING_TURF_BELOW(b)
+	// Keep going down until we reach the bottom or something that has a valid z_depth
+	while (nextb && !nextb.z_depth)
+		b = nextb
+		nextb = b.below || MAPPING_TURF_BELOW(b)
+	// Set the base zdepth
+	b.z_depth = 0
+	// Begin building up, we know there is at least 1 turf above
+	var/turf/a = b.above || MAPPING_TURF_ABOVE(b)
+	var/turf/nexta = a.above || MAPPING_TURF_ABOVE(a)
+	a.z_depth = b.z_depth + 1
+	// Continue up until we build all the way to the top
+	while (nexta)
+		nexta.z_depth = a.z_depth + 1
+		a = nexta
+		nexta = a.above || MAPPING_TURF_ABOVE(a)
+	// Return whatever we were assigned during this process
+	return z_depth

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -117,7 +117,7 @@ By design, d1 is the smallest direction and d2 is the highest
 				R = locate(/obj/item/stack/cable_coil) in T
 			if(R)
 				transfer_fingerprints_to(R)
-		var/turf/T_below = T.below()
+		var/turf/T_below = GET_TURF_BELOW(T)
 		if((d1 == DOWN || d2 == DOWN) && T_below)
 			for(var/obj/structure/cable/C in T_below)
 				if(C.d1 == UP || C.d2 == UP)
@@ -614,7 +614,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 			new /obj/item/stack/cable_coil(get_turf(C), 1, C.color)
 			C.deconstruct()
 	else if(d2 == DOWN)
-		place_cable(T.below(), user, 0, UP)
+		place_cable(GET_TURF_BELOW(T), user, 0, UP)
 		to_chat(user, "<span class='notice'>You slide the cable downward.</span>")
 
 	return C
@@ -670,7 +670,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 		return
 
 	var/dirn = get_dir(C, user)
-	if(T.allow_z_travel && T.below() && !locate(/obj/structure/lattice/catwalk, T))
+	if(T.allow_z_travel && GET_TURF_BELOW(T) && !locate(/obj/structure/lattice/catwalk, T))
 		dirn = DOWN
 	if(forceddir)
 		dirn = forceddir

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
@@ -81,8 +81,8 @@
 /datum/orbital_object/meteor/proc/meteor_impact(turf/T)
 	//Make it so meteors fall from high Z and will impact the top Z-Levels first
 	var/turf/target_turf = T
-	var/turf/next = target_turf.above()
+	var/turf/next = GET_TURF_ABOVE(target_turf)
 	while (next != null)
 		target_turf = next
-		next = target_turf.above()
+		next = GET_TURF_ABOVE(target_turf)
 	new /obj/effect/falling_meteor(target_turf, meteor_types ? pick(meteor_types) : null)


### PR DESCRIPTION
Virtual multi-z

Update zcopy.dm

Fixes the overlays not updating properly.

Fixes virtual multi-z atmos

Above and below VV support

Update the turf adjacency on a multi-z linking update

Makes VV below/above forced

Cherrypick of https://github.com/BeeStation/BeeStation-Hornet/pull/9752